### PR TITLE
Do not fetch a new refresh token on every request

### DIFF
--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -59,7 +59,7 @@ module Salesforceapi
 
       def config_authorization!
         target = CGI::unescape("https://login.salesforce.com/services/oauth2/token?grant_type=refresh_token&client_id=#{@client_id}&client_secret=#{@client_secret}&refresh_token=#{@refresh_token}")
-        resp = SalesforceApi::Request.do_request("POST", target, {"content-Type" => 'application/json'}, nil)
+        resp = post(target, {"content-Type" => 'application/json'})
         if (resp.code != 200) || !resp.success?
           message = ActiveSupport::JSON.decode(resp.body)["error_description"]
           SalesforceApi::Errors::ErrorManager.raise_error(message, 401)

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -33,10 +33,10 @@ module Salesforceapi
         @api_version = "v21.0"
         @ssl_port = 443  # TODO, right SF use port 443 for all HTTPS traffic.
 
+        config_authorization!
       end
 
       def create(object, attributes)
-        config_authorization!
         path = "/services/data/#{@api_version}/sobjects/#{object}/"
         target = @instance_uri + path
 
@@ -45,7 +45,6 @@ module Salesforceapi
 
       def describe(object)
         path = "/services/data/#{@api_version}/sobjects/#{object}/describe"
-        config_authorization!
         target = @instance_uri + path
 
         get(target, @auth_header)
@@ -53,7 +52,6 @@ module Salesforceapi
 
       def resources
         path = "/services/data/#{@api_version}"
-        config_authorization!
         target = @instance_uri + path
 
         get(target, @auth_header)


### PR DESCRIPTION
Fetching a new token for each request is unnecessary and can cause accounts to go over their API limits. `Salesforceapi::Rest::Client#config_authorization!` can still be called manually to get a new refresh token.
